### PR TITLE
update to install packages from Debian 11 stable release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM nfcore/base:1.9
 LABEL authors="Mika Yoshimura and Haruka Ozaki" \
       description="Docker image containing all software requirements for the ramdaq pipeline"
 
-RUN apt update && \
-    apt install -y --no-install-recommends libtbb2
+RUN sed -i "s/buster/bullseye/g" /etc/apt/sources.list &&  \
+    sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+
+RUN apt-get update && \
+    apt-get install -y libtbb2
 
 # Install the conda environment
 COPY environment.yml /


### PR DESCRIPTION
# ramdaq pull request

理化学研究所のデベロッパー様、

お世話になっております。

H.U.グループ中央研究所のケリーと申します。ご対応を宜しくお願い致します。

Many thanks for developing ramdaq!

The current version causes a build error with the Dockerfile since Debian 10 is now "oldstable" and Debian 11 is "stable". This PR adds an additional step to install Debian dependencies from the new version. It runs `docker built -t ramdaq:latest .` without errors.

This is a minor bug I think further testing is not necessary. Please tell me if you have any questions.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Ensure the test suite passes (`nextflow run rikenbit/ramdaq -profile test,docker`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

